### PR TITLE
Saving and loading replay buffer with HDF5 (#261)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ MUJOCO_LOG.TXT
 .DS_Store
 *.zip
 *.pstats
+*.swp

--- a/docs/bibtex.json
+++ b/docs/bibtex.json
@@ -1,0 +1,9 @@
+{
+    "cited": {
+        "tutorials/dqn": [
+            "DQN",
+            "DDPG",
+            "PPO"
+        ]
+    }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,7 @@ autodoc_default_options = {
         ]
     )
 }
+bibtex_bibfiles = ['refs.bib']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,11 @@ setup(
     install_requires=[
         "gym>=0.15.4",
         "tqdm",
-        "numpy",
+        "numpy!=1.16.0",  # https://github.com/numpy/numpy/issues/12793
         "tensorboard",
         "torch>=1.4.0",
         "numba>=0.51.0",
+        "h5py>=3.1.0"
     ],
     extras_require={
         "dev": [

--- a/tianshou/data/utils/converter.py
+++ b/tianshou/data/utils/converter.py
@@ -1,8 +1,10 @@
+import h5py
 import torch
+import pickle
 import numpy as np
 from copy import deepcopy
 from numbers import Number
-from typing import Union, Optional
+from typing import Dict, Union, Optional
 
 from tianshou.data.batch import _parse_value, Batch
 
@@ -80,3 +82,90 @@ def to_torch_as(
     """
     assert isinstance(y, torch.Tensor)
     return to_torch(x, dtype=y.dtype, device=y.device)
+
+
+# Note: object is used as a proxy for objects that can be pickled
+# Note: mypy does not support cyclic definition currently
+Hdf5ConvertibleValues = Union[  # type: ignore
+    int, float, Batch, np.ndarray, torch.Tensor, object,
+    'Hdf5ConvertibleType',  # type: ignore
+]
+
+Hdf5ConvertibleType = Dict[str, Hdf5ConvertibleValues]  # type: ignore
+
+
+def to_hdf5(x: Hdf5ConvertibleType, y: h5py.Group) -> None:
+    """Copy object into HDF5 group."""
+
+    def to_hdf5_via_pickle(x: object, y: h5py.Group, key: str) -> None:
+        """Pickle, convert to numpy array and write to HDF5 dataset."""
+        data = np.frombuffer(pickle.dumps(x), dtype=np.byte)
+        y.create_dataset(key, data=data)
+
+    for k, v in x.items():
+        if isinstance(v, (Batch, dict)):
+            # dicts and batches are both represented by groups
+            subgrp = y.create_group(k)
+            if isinstance(v, Batch):
+                subgrp_data = v.__getstate__()
+                subgrp.attrs["__data_type__"] = "Batch"
+            else:
+                subgrp_data = v
+            to_hdf5(subgrp_data, subgrp)
+        elif isinstance(v, torch.Tensor):
+            # PyTorch tensors are written to datasets
+            y.create_dataset(k, data=to_numpy(v))
+            y[k].attrs["__data_type__"] = "Tensor"
+        elif isinstance(v, np.ndarray):
+            try:
+                # NumPy arrays are written to datasets
+                y.create_dataset(k, data=v)
+                y[k].attrs["__data_type__"] = "ndarray"
+            except TypeError:
+                # If data type is not supported by HDF5 fall back to pickle.
+                # This happens if dtype=object (e.g. due to entries being None)
+                # and possibly in other cases like structured arrays.
+                try:
+                    to_hdf5_via_pickle(v, y, k)
+                except Exception as e:
+                    raise RuntimeError(
+                        f"Attempted to pickle {v.__class__.__name__} due to "
+                        "data type not supported by HDF5 and failed."
+                    ) from e
+                y[k].attrs["__data_type__"] = "pickled_ndarray"
+        elif isinstance(v, (int, float)):
+            # ints and floats are stored as attributes of groups
+            y.attrs[k] = v
+        else:  # resort to pickle for any other type of object
+            try:
+                to_hdf5_via_pickle(v, y, k)
+            except Exception as e:
+                raise NotImplementedError(
+                    f"No conversion to HDF5 for object of type '{type(v)}' "
+                    "implemented and fallback to pickle failed."
+                ) from e
+            y[k].attrs["__data_type__"] = v.__class__.__name__
+
+
+def from_hdf5(
+    x: h5py.Group, device: Optional[str] = None
+) -> Hdf5ConvertibleType:
+    """Restore object from HDF5 group."""
+    if isinstance(x, h5py.Dataset):
+        # handle datasets
+        if x.attrs["__data_type__"] == "ndarray":
+            y = np.array(x)
+        elif x.attrs["__data_type__"] == "Tensor":
+            y = torch.tensor(x, device=device)
+        else:
+            y = pickle.loads(x[()])
+    else:
+        # handle groups representing a dict or a Batch
+        y = {k: v for k, v in x.attrs.items() if k != "__data_type__"}
+        for k, v in x.items():
+            y[k] = from_hdf5(v, device)
+        if "__data_type__" in x.attrs:
+            # if dictionary represents Batch, convert to Batch
+            if x.attrs["__data_type__"] == "Batch":
+                y = Batch(y)
+    return y


### PR DESCRIPTION
As mentioned in #260, this pull request is about an implementation of saving and loading the replay buffer with HDF5.

- [ ] I have marked all applicable categories:
    + [ ] exception-raising fix
    + [ ] algorithm implementation fix
    + [ ] documentation modification
    + [ ] new feature
- [ ] If applicable, I have mentioned the relevant/related issue(s)

Less important but also useful:

- [ ] I have visited the [source website](https://github.com/thu-ml/tianshou)
- [ ] I have searched through the [issue tracker](https://github.com/thu-ml/tianshou/issues) for duplicates
- [ ] I have mentioned version numbers, operating system and environment, where applicable:
  ```python
  import tianshou, torch, sys
  print(tianshou.__version__, torch.__version__, sys.version, sys.platform)
  ```
